### PR TITLE
feat: enhance RouteMap component with OpenTopoMap style

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -452,6 +452,7 @@ dist/
 .fusebox/
 
 # Vite
+.vite/
 dist-ssr
 *.local
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Explore mountain routes through maps, elevation data, and spatial analysis.
 
-Mountain Route Explorer is a web application that helps visualize and analyze GPX tracks.  
+Peakline is a web application that helps visualize and analyze GPX tracks.  
 The project focuses on understanding terrain, elevation structure, and route characteristics through an interactive map interface.
 
 

--- a/docs/runtime-notes.md
+++ b/docs/runtime-notes.md
@@ -1,0 +1,15 @@
+## GPX parsing
+
+Current implementation uses XDocument.
+
+Pros:
+- simple
+- easy to read
+- good for v1
+
+Cons:
+- loads entire XML into memory
+- may be inefficient for large GPX files
+
+Possible improvement:
+- streaming parser with XmlReader

--- a/frontend/src/components/RouteMap/RouteMap.tsx
+++ b/frontend/src/components/RouteMap/RouteMap.tsx
@@ -19,9 +19,35 @@ export function RouteMap({ track }: Props) {
 
     mapRef.current = new maplibregl.Map({
       container: mapContainerRef.current,
-      style: "https://demotiles.maplibre.org/style.json",
+      style: {
+        version: 8,
+        sources: {
+          opentopomap: {
+            type: "raster",
+            tiles: [
+              "https://a.tile.opentopomap.org/{z}/{x}/{y}.png",
+              "https://b.tile.opentopomap.org/{z}/{x}/{y}.png",
+              "https://c.tile.opentopomap.org/{z}/{x}/{y}.png",
+            ],
+            tileSize: 256,
+            maxzoom: 17,
+            attribution:
+              'Map data: © <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, ' +
+              'SRTM | Map style: © <a href="https://opentopomap.org">OpenTopoMap</a> ' +
+              '(<a href="https://creativecommons.org/licenses/by-sa/3.0/">CC-BY-SA</a>)',
+          },
+        },
+        layers: [
+          {
+            id: "opentopomap",
+            type: "raster",
+            source: "opentopomap",
+          },
+        ],
+      },
       center: [37.6173, 55.7558],
       zoom: 4,
+      maxZoom: 17,
     });
 
     mapRef.current.addControl(new maplibregl.NavigationControl(), "top-right");


### PR DESCRIPTION
<img width="1115" height="567" alt="image" src="https://github.com/user-attachments/assets/1ffa1128-aec2-42ef-a96b-64909af22ad8" />

Adds an interactive MapLibre map for displaying analyzed GPX tracks in the frontend.
Updates the project documentation to reflect the current route visualization flow and notes GPX parsing tradeoffs.

-  Added RouteMap component with OpenTopoMap tiles
-  Rendered uploaded GPX track as a GeoJSON line on the map
-  Auto-fit map bounds to the analyzed route
-  Integrated route map into the home page
-  Updated README with current features, architecture, and roadmap
-  Added runtime notes for GPX parsing limitations
-  Updated .gitignore for local/editor/build artifacts